### PR TITLE
Use portable methods when dealing with paths

### DIFF
--- a/RhubarbEngine/Components/Interaction/WebBrowser.cs
+++ b/RhubarbEngine/Components/Interaction/WebBrowser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -352,7 +353,7 @@ namespace RhubarbEngine.Components.Interaction
             {
                 Console.WriteLine("Init Cef");
                 var cefSettings = new CefSettings();
-                cefSettings.CachePath = engine.dataPath + @"\WebBrowser";
+                cefSettings.CachePath = Path.Combine(engine.dataPath, "WebBrowser");
                 cefSettings.CefCommandLineArgs.Add("enable-media-stream", "1");
                 cefSettings.CefCommandLineArgs.Add("disable-usb-keyboard-detect", "1");
                 cefSettings.EnableAudio();

--- a/RhubarbEngine/Engine.cs
+++ b/RhubarbEngine/Engine.cs
@@ -36,7 +36,7 @@ namespace RhubarbEngine
 
         public UnitLogs logger;
 
-        public string dataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "\\RhubarbVR";
+        public string dataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "RhubarbVR");
 
         public FileStream lockFile;
 
@@ -101,7 +101,7 @@ namespace RhubarbEngine
             }
             try
             {
-                lockFile = new FileStream(dataPath + "\\locker.lock", FileMode.OpenOrCreate);
+                lockFile = new FileStream(Path.Combine(dataPath, "locker.lock"), FileMode.OpenOrCreate);
             }
             catch
             {

--- a/RhubarbEngine/Managers/NetApiManager.cs
+++ b/RhubarbEngine/Managers/NetApiManager.cs
@@ -51,7 +51,7 @@ namespace RhubarbEngine.Managers
             string text = "";
             try
             {
-                text = File.ReadAllText(engine.dataPath + "\\auth.token");
+                text = File.ReadAllText(Path.Combine(engine.dataPath, "auth.token"));
             }
             catch
             {
@@ -121,14 +121,14 @@ namespace RhubarbEngine.Managers
             setToken(auth.Token, auth.User);
             if (rememberme)
             {
-                File.WriteAllText(engine.dataPath + "\\auth.token", token);
+                File.WriteAllText(Path.Combine(engine.dataPath, "auth.token"), token);
             }
         }
         public void register(string email, string password, string username,DateTime birthday)
         {
             var auth = authApi.AuthRegisterPost(new RegesterReg(username, password,email, birthday));
             setToken(auth.Token, auth.User);
-            File.WriteAllText(engine.dataPath + "\\auth.token", token);
+            File.WriteAllText(Path.Combine(engine.dataPath, "auth.token"), token);
         }
 
         public void logout()
@@ -139,7 +139,7 @@ namespace RhubarbEngine.Managers
             onlogout?.Invoke();
             try
             {
-                File.Delete(engine.dataPath + "\\auth.token");
+                File.Delete(Path.Combine(engine.dataPath, "auth.token"));
             }
             catch { }
             statusApi.StatusClearstatusGet(token);

--- a/RhubarbEngine/UnitLogs.cs
+++ b/RhubarbEngine/UnitLogs.cs
@@ -27,7 +27,7 @@ namespace RhubarbEngine
             {
                 Directory.CreateDirectory(logDir);
             }
-            objFilestream = new FileStream(string.Format("{0}\\{1}", logDir, logFile), FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            objFilestream = new FileStream(Path.Combine(logDir, logFile), FileMode.OpenOrCreate, FileAccess.ReadWrite);
             objStreamWriter = new StreamWriter((Stream)objFilestream);
         }
 

--- a/RhubarbEngine/VirtualReality/OpenVR/OpenVRContext.cs
+++ b/RhubarbEngine/VirtualReality/OpenVR/OpenVRContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -91,12 +92,12 @@ namespace RhubarbEngine.VirtualReality.OpenVR
 
             Logger.Log("Loading app.vrmanifest");
             EVRApplicationError apperro = EVRApplicationError.None;
-            apperro = OVR.Applications.AddApplicationManifest(AppDomain.CurrentDomain.BaseDirectory + @"\\app.vrmanifest", false);
+            apperro = OVR.Applications.AddApplicationManifest(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "app.vrmanifest"), false);
             if (apperro != EVRApplicationError.None) Logger.Log($"Failed to load Application Manifest: {Enum.GetName(typeof(EVRApplicationError), apperro)}", true);
             else Logger.Log("Application manifest loaded successfully.");
 
             _mirrorTexture = new OpenVRMirrorTexture(this);
-            EVRInputError error = OVR.Input.SetActionManifestPath(AppDomain.CurrentDomain.BaseDirectory + @"\\SteamVR\\steamvr_manifest.json");
+            EVRInputError error = OVR.Input.SetActionManifestPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "SteamVR", "steamvr_manifest.json"));
             if (error != EVRInputError.None)
             {
                 Logger.Log($"Action manifest error {error.ToString()}");

--- a/RhubarbEngine/World/World.cs
+++ b/RhubarbEngine/World/World.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -638,10 +639,10 @@ namespace RhubarbEngine.World
             Mobilefriendly.value = mobilefriendly;
             if(templet != null)
             {
-                string path = AppDomain.CurrentDomain.BaseDirectory + @"\WorldTemplets\";
+                string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "WorldTemplets");
                 try
                 {
-                    var data = System.IO.File.ReadAllBytes(path + templet + ".RWorld");
+                    var data = System.IO.File.ReadAllBytes(Path.Combine(path, templet + ".RWorld"));
                     DataNodeGroup node = new DataNodeGroup(data);
                     List<Action> loadded = new List<Action>();
                     deSerialize(node, loadded, true, new Dictionary<ulong, ulong>(), new Dictionary<ulong, List<RefIDResign>>());

--- a/SteamAudio.NET/AL.cs
+++ b/SteamAudio.NET/AL.cs
@@ -3,84 +3,84 @@ using System.Runtime.InteropServices;
 
 namespace OpenAL
 {
-	//This class contains only the most necessary functions & values that were used in the test.
-	public unsafe static class AL
-	{
+    //This class contains only the most necessary functions & values that were used in the test.
+    public unsafe static class AL
+    {
 #if Windows
-		public const string Library =  "Natives\\Windows64\\soft_oal.dll";
+        public const string Library = "Natives\\Windows64\\soft_oal.dll";
 #elif Linux
-		public const string Library = "SteamAudio.NET\\Natives\\Linux64\\libopenal.so.1";
+        public const string Library = "SteamAudio.NET/Natives/Linux64/libopenal.so.1";
 #elif OSX
-		public const string Library = "Natives\\OSX64\\libopenal.dylib";
+        public const string Library = "Natives/OSX64/libopenal.dylib";
 #endif
-		public enum SourceState
-		{
-			Initial = 0x1011,
-			Playing = 0x1012,
-			Paused = 0x1013,
-			Stopped = 0x1014,
-		}
+        public enum SourceState
+        {
+            Initial = 0x1011,
+            Playing = 0x1012,
+            Paused = 0x1013,
+            Stopped = 0x1014,
+        }
 
-		public enum GetSourceInt
-		{
-			SourceState = 0x1010,
-			BuffersQueued = 0x1015,
-			BuffersProcessed = 0x1016,
-		}
+        public enum GetSourceInt
+        {
+            SourceState = 0x1010,
+            BuffersQueued = 0x1015,
+            BuffersProcessed = 0x1016,
+        }
 
-		public enum Error
-		{
-			NoError = 0x0000,
-			InvalidName = 0xA001,
-			InvalidEnum = 0xA002,
-			InvalidValue = 0xA003,
-			InvalidOperation = 0xA004,
-			OutOfMemory = 0xA005
-		}
+        public enum Error
+        {
+            NoError = 0x0000,
+            InvalidName = 0xA001,
+            InvalidEnum = 0xA002,
+            InvalidValue = 0xA003,
+            InvalidOperation = 0xA004,
+            OutOfMemory = 0xA005
+        }
 
-		static AL() => SteamAudio.DllManager.PrepareResolver();
+        static AL() => SteamAudio.DllManager.PrepareResolver();
 
-		//General
+        //General
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alIsExtensionPresent")]
-		public static extern bool IsExtensionPresent([In] [MarshalAs(UnmanagedType.LPStr)] string extName);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alIsExtensionPresent")]
+        public static extern bool IsExtensionPresent([In] [MarshalAs(UnmanagedType.LPStr)] string extName);
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGetError")]
-		public static extern Error GetError();
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGetError")]
+        public static extern Error GetError();
 
-		//Buffers
+        //Buffers
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGenBuffers")]
-		public static extern void GenBuffers(int numBuffers, uint[] bufferIdOutputArray);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGenBuffers")]
+        public static extern void GenBuffers(int numBuffers, uint[] bufferIdOutputArray);
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alBufferData")]
-		public static extern void BufferData(uint buffer, uint format, IntPtr data, int size, int frequency);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alBufferData")]
+        public static extern void BufferData(uint buffer, uint format, IntPtr data, int size, int frequency);
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alBufferData")]
-		public static extern void BufferData(uint buffer, uint format, byte[] data, int size, int frequency);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alBufferData")]
+        public static extern void BufferData(uint buffer, uint format, byte[] data, int size, int frequency);
 
-		//Sources
+        //Sources
 
-		public static void GenSource(out uint sourceId)
-		{
-			fixed(uint* ptr = &sourceId) {
-				GenSources(1, ptr);
-			}
-		}
+        public static void GenSource(out uint sourceId)
+        {
+            fixed(uint* ptr = &sourceId) {
+                GenSources(1, ptr);
+            }
+        }
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGenSources")]
-		private static extern void GenSources(int numSources, [Out] uint* sourceIds);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGenSources")]
+        private static extern void GenSources(int numSources, [Out] uint* sourceIds);
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGetSourcei")]
-		public static extern void GetSource(uint sourceId, GetSourceInt parameter, out int value);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alGetSourcei")]
+        public static extern void GetSource(uint sourceId, GetSourceInt parameter, out int value);
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alSourcePlay")]
-		public static extern void SourcePlay(uint sourceId);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alSourcePlay")]
+        public static extern void SourcePlay(uint sourceId);
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alSourceQueueBuffers")]
-		public unsafe static extern void SourceQueueBuffers(uint sourceId, int numBuffers, [Out] uint* bufferIds);
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alSourceQueueBuffers")]
+        public unsafe static extern void SourceQueueBuffers(uint sourceId, int numBuffers, [Out] uint* bufferIds);
 
-		[DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alSourceUnqueueBuffers")]
-		public unsafe static extern void SourceUnqueueBuffers(uint sourceId, int numBuffers, [Out] uint* bufferIds);
-	}
+        [DllImport(Library, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, ExactSpelling = true, EntryPoint = "alSourceUnqueueBuffers")]
+        public unsafe static extern void SourceUnqueueBuffers(uint sourceId, int numBuffers, [Out] uint* bufferIds);
+    }
 }

--- a/SteamAudio.NET/IPL.cs
+++ b/SteamAudio.NET/IPL.cs
@@ -1,13 +1,13 @@
 ﻿namespace SteamAudio
 {
-	public static partial class IPL
-	{
+    public static partial class IPL
+    {
 #if Windows
         public const string Library = "Natives\\Windows64\\phonon.dll";
 #elif Linux
-		public const string Library = "Natives\\Linux64\\libphonon.so";
+        public const string Library = "Natives/Linux64/libphonon.so";
 #elif OSX
-		public const string Library = "Natives\\OSX64\\libphonon.dylib";
+        public const string Library = "Natives/OSX64/libphonon.dylib";
 #endif
 
         static IPL() => DllManager.PrepareResolver();


### PR DESCRIPTION
Most of this was discovered by looking for any series of two backslashes using grep. I then followed up by looking for any verbatim strings followed by a single backslash (e.g. `@"foo\bar"`) which caught a couple of cases I missed.

I also had to touch a couple of files which were using the wrong indentation type, so I've updated them to be consistent with the rest of the project.

( Going through this I have a follow-up question: There are places where "template" is misspelt as "templet", would that be worth cleaning up as well? It will have compatibility implications. But that's for another PR... hmm, would it be worth enabling discussion forums on this repository? )